### PR TITLE
Adding support for server rendered import map. Resolves #13. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,15 +70,25 @@ import "import-map-overrides"; // this only will work if you compile the `import
 
 ## Configuration
 
-If you are using import-map-overrides for native import maps, no configuration is required.
-
-However, if you're using SystemJS as a polyfill for import maps, you'll need to tell import-map-overrides to make a
-`<script type="systemjs-importmap">` element instead of `<script type="importmap">`. To do this, you must add a `<meta>`
+You must indicate what kind of import map you are setting overrides for. You do this by inserting you must add a `<meta>`
 element to your html file **before the import-map-overrides library is loaded**.
 
 ```html
+<!-- example configuration for a SystemJS import map -->
 <meta name="importmap-type" content="systemjs-importmap" />
 ```
+
+| Import Map type                                                  | `importmap-type`      |
+| ---------------------------------------------------------------- | --------------------- |
+| Native <sup>1</sup>                                              | `importmap` (default) |
+| [SystemJS](https://github.com/systemjs/systemjs)                 | `systemjs-importmap`  |
+| [es-module-shims](https://github.com/guybedford/es-module-shims) | `importmap-shim`      |
+| Server rendered <sup>2</sup>                                     | `server`              |
+
+**Notes:**
+
+1. Native import maps are only supported in Chrome@>=76 under the _Experimental Web Platform Features_ flag. Only one import map (including the import-map-overrides map) can be on a web page at a time when using native import maps. ([Details](https://github.com/WICG/import-maps/issues/199))
+2. A "server rendered import map" is when the web server for your HTML file embeds an inline import map. You can still use import-map-overrides for such import maps if your server is cooperative. Import map overrides will set a cookie called `import-map-overrides:module-name` whose value is the override URL. A cooperative server is one that applies the URL in the cookie to the inlined import map sent in the response HTML.
 
 ## Integration with other import maps
 

--- a/src/api/js-api.js
+++ b/src/api/js-api.js
@@ -2,6 +2,16 @@ const localStoragePrefix = "import-map-override:";
 
 const portRegex = /^\d+$/g;
 
+const importMapMetaElement = document.querySelector(
+  'meta[name="importmap-type"]'
+);
+
+export const importMapType = importMapMetaElement
+  ? importMapMetaElement.getAttribute("content")
+  : "importmap";
+
+const serverOverrides = importMapType === "server";
+
 window.importMapOverrides = {
   addOverride(moduleName, url) {
     if (portRegex.test(url)) {
@@ -9,6 +19,9 @@ window.importMapOverrides = {
     }
     const key = localStoragePrefix + moduleName;
     localStorage.setItem(key, url);
+    if (serverOverrides) {
+      document.cookie = `${key}=${url}`;
+    }
     fireChangedEvent();
     return window.importMapOverrides.getOverrideMap();
   },
@@ -29,6 +42,9 @@ window.importMapOverrides = {
     const key = localStoragePrefix + moduleName;
     const hasItem = localStorage.getItem(key) !== null;
     localStorage.removeItem(key);
+    if (serverOverrides) {
+      document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+    }
     fireChangedEvent();
     return hasItem;
   },
@@ -79,12 +95,6 @@ function fireChangedEvent() {
 }
 
 const overrideMap = window.importMapOverrides.getOverrideMap();
-const importMapMetaElement = document.querySelector(
-  'meta[name="importmap-type"]'
-);
-export const importMapType = importMapMetaElement
-  ? importMapMetaElement.getAttribute("content")
-  : "importmap";
 
 if (Object.keys(overrideMap.imports).length > 0) {
   const overrideMapElement = document.createElement("script");

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Import Map Overrides test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="importmap-type" content="server" />
     <script type="importmap">
       {
         "imports": {


### PR DESCRIPTION
See #13. This is similar to what Canopy used to do for import map overrides.

![image](https://user-images.githubusercontent.com/5524384/77008100-23999780-692b-11ea-8eeb-55f6a58a4654.png)
