### PR TITLE
Add ability to disable modules. Also added new APIs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with native browser import maps or with the [SystemJS](https://github.com/system
 
 ## Motivation
 
-![import-map-overrides-ui](https://user-images.githubusercontent.com/5524384/60623188-484ede80-9d9f-11e9-9c1c-cb9fb09f8bee.gif)
+![import map overrides 3](https://user-images.githubusercontent.com/5524384/77237035-07476600-6b8a-11ea-9041-8b70f633d5d0.gif)
 
 Import maps are a way of controlling which url to download javascript modules from. The import-map-overrides library allows you
 to dynamically change the url for javascript modules by storing overrides in local storage. This allows developers to **override individual modules to point to their localhost during development of a module, without having to boot up a local environment with all the other modules and a backend server.**

--- a/README.md
+++ b/README.md
@@ -120,11 +120,13 @@ The `overridable-importmap` will be ignored by the browser, but import-map-overr
 import-map-overrides provides the following functions. Note that these functions are always put onto window.importMapOverrides, even
 if you installed it as an npm package.
 
-### `window.importMapOverrides.getOverrideMap()`
+### `window.importMapOverrides.getOverrideMap(includeDisabled? = false)`
 
 Returns the override import map as an object. The returned object represents the overrides
 **that will take effect the next time you reload the page**, including any additions or removals you've recently made after
 the current page's [acquiringImportMaps boolean](https://github.com/WICG/import-maps/blob/master/spec.md#acquiring-import-maps) was set to false.
+
+`includeDisabled` is an optional boolean you can pass in to include any "disabled overrides." See `disableOverride()` for more information.
 
 ```js
 const overrideMap = window.importMapOverrides.getOverrideMap();
@@ -204,7 +206,39 @@ It will set local storage to match the `show-when-local-storage` key and/or it w
 
 ### `window.importMapOverrides.mergeImportMap(firstMap, secondMap)`
 
-Merges the second import map into the first. This API mutates the firstMap, it does not create a new map. Returns the modified firstMap.
+Creates a new import map that is the first map merged with the second map. Items in the second map take priority.
+
+### `window.importMapOverrides.getDefaultMap()`
+
+This returns the import map(s) on the page, without the presence of any import map overrides.
+
+### `window.importMapOverrides.getCurrentPageMap()`
+
+This returns the final import map (including overrides) that was applied to the current page. Any overrides set after the page load will not be included.
+
+### `window.importMapOverrides.getNextPageMap()`
+
+This returns the final import map (including overrides) that will be applied the next time the page is reloaded.
+
+### `window.importMapOverrides.disableOverride(moduleName)`
+
+This will temporarily disable an import map override. This is similar to `removeOverride()` except that it will preserve what the override URL was so that you can toggle the override on and off.
+
+Returns true if the module was already disabled, and false otherwise.
+
+### `window.importMapOverrides.enableOverride(moduleName)`
+
+This will re-renable an import map override that was previously disabled via `disableOverride()`.
+
+Returns true if the module was already disabled, and false otherwise.
+
+### `window.importMapOverrides.getDisabledOverrides()`
+
+Returns an array of strings, where each string is the name of a module that is currently disabled.
+
+### `window.importMapOverrides.isDisabled(moduleName)`
+
+Returns a boolean indicated whether the string module name is a currently disabled or not.
 
 ## Events
 

--- a/src/api/js-api.js
+++ b/src/api/js-api.js
@@ -1,4 +1,5 @@
 const localStoragePrefix = "import-map-override:";
+const disabledOverridesLocalStorageKey = "import-map-overrides-disabled";
 
 const portRegex = /^\d+$/g;
 
@@ -11,6 +12,8 @@ export const importMapType = importMapMetaElement
   : "importmap";
 
 const serverOverrides = importMapType === "server";
+
+let defaultMapPromise;
 
 window.importMapOverrides = {
   addOverride(moduleName, url) {
@@ -25,17 +28,18 @@ window.importMapOverrides = {
     fireChangedEvent();
     return imo.getOverrideMap();
   },
-  getOverrideMap() {
+  getOverrideMap(includeDisabled = false) {
     const overrides = { imports: {} };
+    const disabledOverrides = imo.getDisabledOverrides();
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
       if (key.startsWith(localStoragePrefix)) {
-        overrides.imports[
-          key.slice(localStoragePrefix.length)
-        ] = localStorage.getItem(key);
+        const moduleName = key.slice(localStoragePrefix.length);
+        if (includeDisabled || !disabledOverrides.includes(moduleName)) {
+          overrides.imports[moduleName] = localStorage.getItem(key);
+        }
       }
     }
-
     return overrides;
   },
   removeOverride(moduleName) {
@@ -45,13 +49,15 @@ window.importMapOverrides = {
     if (serverOverrides) {
       document.cookie = `${key}=; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
     }
+    imo.enableOverride(moduleName);
     fireChangedEvent();
     return hasItem;
   },
   resetOverrides() {
-    Object.keys(imo.getOverrideMap().imports).forEach(moduleName => {
+    Object.keys(imo.getOverrideMap(true).imports).forEach(moduleName => {
       imo.removeOverride(moduleName);
     });
+    localStorage.removeItem(disabledOverridesLocalStorageKey);
     fireChangedEvent();
     return imo.getOverrideMap();
   },
@@ -80,13 +86,101 @@ window.importMapOverrides = {
     }
   },
   mergeImportMap(originalMap, newMap) {
+    const outMap = { imports: {}, scopes: {} };
+    for (let i in originalMap.imports) {
+      outMap.imports[i] = originalMap.imports[i];
+    }
     for (let i in newMap.imports) {
-      originalMap.imports[i] = newMap.imports[i];
+      outMap.imports[i] = newMap.imports[i];
+    }
+    for (let i in originalMap.scopes) {
+      outMap.scopes[i] = originalMap.scopes[i];
     }
     for (let i in newMap.scopes) {
-      originalMap.scopes[i] = newMap.scopes[i];
+      outMap.scopes[i] = newMap.scopes[i];
     }
-    return originalMap;
+    return outMap;
+  },
+  getDefaultMap() {
+    return (
+      defaultMapPromise ||
+      (defaultMapPromise = Array.prototype.reduce.call(
+        document.querySelectorAll(
+          `script[type="${importMapType}"], script[type="overridable-importmap"]`
+        ),
+        (promise, scriptEl) => {
+          if (scriptEl.id === "import-map-overrides") {
+            return promise;
+          } else {
+            let nextPromise;
+            if (scriptEl.src) {
+              nextPromise = fetch(scriptEl.src).then(resp => resp.json());
+            } else {
+              nextPromise = Promise.resolve(JSON.parse(scriptEl.textContent));
+            }
+
+            return Promise.all([
+              promise,
+              nextPromise
+            ]).then(([originalMap, newMap]) =>
+              imo.mergeImportMap(originalMap, newMap)
+            );
+          }
+        },
+        Promise.resolve({ imports: {} })
+      ))
+    );
+  },
+  getCurrentPageMap() {
+    return imo.getDefaultMap().then(defaultMap => {
+      const overrideEl = document.querySelector("#import-map-overrides");
+      const overrideMap = overrideEl
+        ? JSON.parse(overrideEl.textContent)
+        : { imports: {} };
+      return imo.mergeImportMap(defaultMap, overrideMap);
+    });
+  },
+  getNextPageMap() {
+    return imo.getDefaultMap().then(defaultMap => {
+      return imo.mergeImportMap(defaultMap, imo.getOverrideMap());
+    });
+  },
+  disableOverride(moduleName) {
+    const disabledOverrides = imo.getDisabledOverrides();
+    if (!disabledOverrides.includes(moduleName)) {
+      localStorage.setItem(
+        disabledOverridesLocalStorageKey,
+        JSON.stringify(disabledOverrides.concat(moduleName))
+      );
+      fireChangedEvent();
+      return true;
+    } else {
+      return false;
+    }
+  },
+  enableOverride(moduleName) {
+    const disabledOverrides = imo.getDisabledOverrides();
+    const index = disabledOverrides.indexOf(moduleName);
+    if (index >= 0) {
+      disabledOverrides.splice(index, 1);
+      localStorage.setItem(
+        disabledOverridesLocalStorageKey,
+        JSON.stringify(disabledOverrides)
+      );
+      fireChangedEvent();
+      return true;
+    } else {
+      return false;
+    }
+  },
+  getDisabledOverrides() {
+    const disabledOverrides = localStorage.getItem(
+      disabledOverridesLocalStorageKey
+    );
+    return disabledOverrides ? JSON.parse(disabledOverrides) : [];
+  },
+  isDisabled(moduleName) {
+    return imo.getDisabledOverrides().includes(moduleName);
   }
 };
 
@@ -121,8 +215,11 @@ if (overridableImportMap) {
     );
   }
 
-  window.importMapOverrides.mergeImportMap(originalMap, overrideMap);
-  insertOverrideMap(originalMap, overridableImportMap);
+  const finalMap = window.importMapOverrides.mergeImportMap(
+    originalMap,
+    overrideMap
+  );
+  insertOverrideMap(finalMap, overridableImportMap);
 } else {
   if (Object.keys(overrideMap.imports).length > 0) {
     const importMaps = document.querySelectorAll(

--- a/src/ui/dev-lib-overrides.component.js
+++ b/src/ui/dev-lib-overrides.component.js
@@ -1,9 +1,8 @@
 import { h, Component } from "preact";
-import { getDefaultMap } from "./list/list.component";
 
 export default class DevLibOverrides extends Component {
   componentDidMount() {
-    getDefaultMap().then(addDevLibOverrides);
+    window.importMapOverrides.getDefaultMap().then(addDevLibOverrides);
   }
   render() {
     return null;
@@ -12,7 +11,8 @@ export default class DevLibOverrides extends Component {
 
 const devLibs = {
   react: url => url.replace("production.min", "development"),
-  "react-dom": url => url.replace("production.min", "development")
+  "react-dom": url => url.replace("production.min", "development"),
+  "single-spa": url => url.replace("single-spa.min.js", "single-spa.dev.js")
 };
 
 function addDevLibOverrides(notOverriddenMap) {

--- a/src/ui/full-ui.component.js
+++ b/src/ui/full-ui.component.js
@@ -31,7 +31,7 @@ export default class FullUI extends Component {
         <button
           onClick={this.toggleTrigger}
           className={`imo-unstyled imo-trigger ${
-            this.atLeastOneOverride() ? "imo-overridden" : ""
+            this.atLeastOneOverride() ? "imo-current-override" : ""
           }`}
         >
           {"{\u00B7\u00B7\u00B7}"}

--- a/src/ui/import-map-overrides.css
+++ b/src/ui/import-map-overrides.css
@@ -73,8 +73,10 @@ imo-popup a {
   margin-bottom: 8px;
 }
 
-.imo-list-container {
+.imo-list-container *,
+.imo-modal-container * {
   font-family: sans-serif;
+  box-sizing: border-box;
 }
 
 .imo-module-dialog {
@@ -111,25 +113,58 @@ imo-popup a {
   border: 4px solid salmon;
 }
 
-.imo-list-container button,
-.imo-modal-container button {
-  padding: 6px 16px;
-  font-size: 16px;
-  text-align: center;
+.imo-table-header-actions {
+  display: flex;
+  align-items: center;
 }
 
-button.imo-default {
-  background-color: navajowhite;
+.imo-overrides-table {
+  border-collapse: collapse;
+  margin-top: 32px;
 }
 
-button.imo-overridden,
-.imo-trigger.imo-overridden {
+.imo-overrides-table tr td:first-child {
+  display: flex;
+  align-items: center;
+}
+
+.imo-status {
+  height: 16px;
+  width: 16px;
+  border-radius: 8px;
+  border: 1px solid white;
+  margin-right: 8px;
+}
+
+.imo-disabled-override {
+  background-color: lightblue;
+}
+
+.imo-next-override {
+  background-color: darkred;
+}
+
+.imo-current-override {
   background-color: salmon;
-  font-weight: bold;
+}
+
+.imo-default-module {
+  background-color: lightgoldenrodyellow;
+}
+
+.imo-overrides-table tbody tr:hover {
+  cursor: pointer;
+  background-color: #404040;
+}
+
+.imo-overrides-table td,
+.imo-overrides-table th {
+  line-height: 18px;
+  padding: 16px;
+  border: 1px solid white;
 }
 
 .imo-add-new {
-  margin-top: 16px;
   margin-left: 16px;
 }
 
@@ -157,6 +192,16 @@ button.imo-overridden,
   z-index: 20000000;
 }
 
+.imo-list-search,
+.imo-list-container button,
+.imo-modal-container button {
+  font-size: 14px;
+  height: 27px;
+  line-height: 27px;
+}
+
 .imo-list-search {
-  font-size: 18px;
+  line-height: 22px;
+  border: none;
+  padding: 5px;
 }

--- a/src/ui/list/list.component.js
+++ b/src/ui/list/list.component.js
@@ -5,14 +5,19 @@ import ModuleDialog from "./module-dialog.component";
 export default class List extends Component {
   state = {
     notOverriddenMap: { imports: {} },
+    currentPageMap: { imports: {} },
     dialogModule: null,
     searchVal: ""
   };
   componentDidMount() {
-    getDefaultMap().then(notOverriddenMap => {
+    window.importMapOverrides.getDefaultMap().then(notOverriddenMap => {
       this.setState({ notOverriddenMap });
     });
+    window.importMapOverrides.getCurrentPageMap().then(currentPageMap => {
+      this.setState({ currentPageMap });
+    });
     window.addEventListener("import-map-overrides:change", this.doUpdate);
+    this.inputRef.focus();
   }
   componentWillUnmount() {
     window.removeEventListener("import-map-overrides:change", this.doUpdate);
@@ -38,97 +43,167 @@ export default class List extends Component {
   }
   render() {
     const overriddenModules = [],
+      nextOverriddenModules = [],
+      disabledOverrides = [],
       defaultModules = [];
 
-    const overrideMap = window.importMapOverrides.getOverrideMap().imports;
+    const overrideMap = window.importMapOverrides.getOverrideMap(true).imports;
 
-    Object.keys(this.state.notOverriddenMap.imports)
-      .filter(this.filterModuleNames)
-      .forEach(moduleName => {
-        const mod = {
-          moduleName,
-          defaultUrl: this.state.notOverriddenMap.imports[moduleName],
-          overrideUrl: overrideMap[moduleName]
-        };
-        if (overrideMap[moduleName]) {
+    const notOverriddenKeys = Object.keys(this.state.notOverriddenMap.imports);
+
+    const disabledModules = window.importMapOverrides.getDisabledOverrides();
+
+    notOverriddenKeys.filter(this.filterModuleNames).forEach(moduleName => {
+      const mod = {
+        moduleName,
+        defaultUrl: this.state.notOverriddenMap.imports[moduleName],
+        overrideUrl: overrideMap[moduleName],
+        disabled: disabledModules.includes(moduleName)
+      };
+      if (mod.disabled) {
+        disabledOverrides.push(mod);
+      } else if (overrideMap[moduleName]) {
+        if (
+          this.state.currentPageMap.imports[moduleName] ===
+          overrideMap[moduleName]
+        ) {
           overriddenModules.push(mod);
         } else {
-          defaultModules.push(mod);
+          nextOverriddenModules.push(mod);
         }
-      });
+      } else {
+        defaultModules.push(mod);
+      }
+    });
 
     Object.keys(overrideMap)
       .filter(this.filterModuleNames)
-      .forEach(overrideKey => {
-        if (!overriddenModules.some(m => m.moduleName === overrideKey)) {
-          overriddenModules.push({
-            moduleName: overrideKey,
+      .forEach(moduleName => {
+        if (!notOverriddenKeys.includes(moduleName)) {
+          const mod = {
+            moduleName,
             defaultUrl: null,
-            overrideUrl: overrideMap[overrideKey]
-          });
+            overrideUrl: overrideMap[moduleName],
+            disabled: disabledModules.includes(moduleName)
+          };
+
+          if (mod.disabled) {
+            disabledOverrides.push(mod);
+          } else if (
+            this.state.currentPageMap.imports[moduleName] ===
+            overrideMap[moduleName]
+          ) {
+            overriddenModules.push(mod);
+          } else {
+            nextOverriddenModules.push(mod);
+          }
         }
       });
 
     overriddenModules.sort(sorter);
     defaultModules.sort(sorter);
+    nextOverriddenModules.sort(sorter);
 
     return (
       <div className="imo-list-container">
-        <div>
+        <div className="imo-table-header-actions">
           <input
             className="imo-list-search"
             aria-label="Search modules"
             placeholder="Search modules"
             value={this.state.searchVal}
             onInput={evt => this.setState({ searchVal: evt.target.value })}
-            autoFocus
+            ref={ref => (this.inputRef = ref)}
           />
+          <div className="imo-add-new">
+            <button
+              onClick={() =>
+                this.setState({
+                  dialogModule: { moduleName: "New module", isNew: true }
+                })
+              }
+            >
+              Add new module
+            </button>
+          </div>
+          <div className="imo-add-new">
+            <button onClick={() => window.importMapOverrides.resetOverrides()}>
+              Reset all overrides
+            </button>
+          </div>
         </div>
-        <div>
-          <h3>Overridden Modules</h3>
-          <div className="imo-list">
-            {overriddenModules.length === 0 && (
-              <div>(No overridden modules)</div>
-            )}
+        <table className="imo-overrides-table">
+          <thead>
+            <tr>
+              <th>Module Status</th>
+              <th>Module Name</th>
+              <th>Domain</th>
+              <th>Filename</th>
+            </tr>
+          </thead>
+          <tbody>
+            {nextOverriddenModules.map(mod => (
+              <tr
+                role="button"
+                tabIndex={0}
+                onClick={() => this.setState({ dialogModule: mod })}
+              >
+                <td>
+                  <div className="imo-status imo-next-override" />
+                  <div>Pending refresh</div>
+                </td>
+                <td>{mod.moduleName}</td>
+                <td>{toDomain(mod)}</td>
+                <td>{toFileName(mod)}</td>
+              </tr>
+            ))}
+            {disabledOverrides.map(mod => (
+              <tr
+                role="button"
+                tabIndex={0}
+                onClick={() => this.setState({ dialogModule: mod })}
+              >
+                <td>
+                  <div className="imo-status imo-disabled-override" />
+                  <div>Override disabled</div>
+                </td>
+                <td>{mod.moduleName}</td>
+                <td>{toDomain(mod)}</td>
+                <td>{toFileName(mod)}</td>
+              </tr>
+            ))}
             {overriddenModules.map(mod => (
-              <div>
-                <button
-                  className="imo-overridden"
-                  onClick={() => this.setState({ dialogModule: mod })}
-                >
-                  {mod.moduleName}
-                </button>
-              </div>
+              <tr
+                role="button"
+                tabIndex={0}
+                onClick={() => this.setState({ dialogModule: mod })}
+              >
+                <td>
+                  <div className="imo-status imo-current-override" />
+                  <div>Override</div>
+                </td>
+                <td>{mod.moduleName}</td>
+                <td>{toDomain(mod)}</td>
+                <td>{toFileName(mod)}</td>
+              </tr>
             ))}
-          </div>
-        </div>
-        <div className="imo-add-new">
-          <button
-            onClick={() =>
-              this.setState({
-                dialogModule: { moduleName: "New module", isNew: true }
-              })
-            }
-          >
-            Add new module
-          </button>
-        </div>
-        <div>
-          <h3>Default Modules</h3>
-          <div className="imo-list">
-            {defaultModules.length === 0 && <div>(No default modules)</div>}
             {defaultModules.map(mod => (
-              <div>
-                <button
-                  className="imo-default"
-                  onClick={() => this.setState({ dialogModule: mod })}
-                >
-                  {mod.moduleName}
-                </button>
-              </div>
+              <tr
+                role="button"
+                tabIndex={0}
+                onClick={() => this.setState({ dialogModule: mod })}
+              >
+                <td>
+                  <div className="imo-status imo-default-module" />
+                  <div>Default</div>
+                </td>
+                <td>{mod.moduleName}</td>
+                <td>{toDomain(mod)}</td>
+                <td>{toFileName(mod)}</td>
+              </tr>
             ))}
-          </div>
-        </div>
+          </tbody>
+        </table>
       </div>
     );
   }
@@ -170,34 +245,34 @@ export default class List extends Component {
   };
 }
 
-export function getDefaultMap() {
-  return Array.prototype.reduce.call(
-    document.querySelectorAll(
-      `script[type="${importMapType}"], script[type="overridable-importmap"]`
-    ),
-    (promise, scriptEl) => {
-      if (scriptEl.id === "import-map-overrides") {
-        return promise;
-      } else {
-        let nextPromise;
-        if (scriptEl.src) {
-          nextPromise = fetch(scriptEl.src).then(resp => resp.json());
-        } else {
-          nextPromise = Promise.resolve(JSON.parse(scriptEl.textContent));
-        }
-
-        return Promise.all([
-          promise,
-          nextPromise
-        ]).then(([originalMap, newMap]) =>
-          window.importMapOverrides.mergeImportMap(originalMap, newMap)
-        );
-      }
-    },
-    Promise.resolve({ imports: {} })
-  );
-}
-
 function sorter(first, second) {
   return first.moduleName > second.moduleName;
+}
+
+const currentBase =
+  (document.querySelector("base") && document.querySelector("base").href) ||
+  location.origin + "/";
+
+function toDomain(mod) {
+  const urlStr = toUrlStr(mod);
+  const url = toURL(urlStr);
+  return url ? url.host : urlStr;
+}
+
+function toFileName(mod) {
+  const urlStr = toUrlStr(mod);
+  const url = toURL(urlStr);
+  return url ? url.pathname.slice(url.pathname.lastIndexOf("/") + 1) : urlStr;
+}
+
+function toUrlStr(mod) {
+  return mod.overrideUrl || mod.defaultUrl;
+}
+
+function toURL(urlStr) {
+  try {
+    return new URL(urlStr, currentBase);
+  } catch {
+    return null;
+  }
 }

--- a/src/ui/list/module-dialog.component.js
+++ b/src/ui/list/module-dialog.component.js
@@ -133,9 +133,30 @@ export default class ModuleDialog extends Component {
               >
                 Cancel
               </button>
+              {this.props.module.overrideUrl && !this.props.module.disabled && (
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (this.props.module.disabled) {
+                      window.importMapOverrides.enableOverride(
+                        this.props.module.moduleName
+                      );
+                    } else {
+                      window.importMapOverrides.disableOverride(
+                        this.props.module.moduleName
+                      );
+                    }
+                    this.props.cancel();
+                  }}
+                  tabIndex={6}
+                  style={{ marginRight: "16px" }}
+                >
+                  {this.props.module.disabled ? "Enable" : "Disable"} Override
+                </button>
+              )}
               <button
                 type="submit"
-                tabIndex={6}
+                tabIndex={7}
                 className={
                   this.state.overrideUrl ? "imo-overridden" : "imo-default"
                 }
@@ -163,6 +184,12 @@ export default class ModuleDialog extends Component {
 
   handleSubmit = evt => {
     evt.preventDefault();
+    if (
+      this.props.module.moduleName &&
+      window.importMapOverrides.isDisabled(this.props.module.moduleName)
+    ) {
+      window.importMapOverrides.enableOverride(this.props.module.moduleName);
+    }
     if (this.props.module.isNew) {
       this.props.addNewModule(this.state.moduleName, this.state.overrideUrl);
     } else {

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
     <script type="overridable-importmap">
       {
         "imports": {
-          "a": "./a.js",
+          "app1": "https://mycdn.com/v1/app.js",
           "react": "https://cdn.jsdelivr.net/npm/react@16.12.0/umd/react.production.min.js",
           "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.12.0/umd/react-dom.production.min.js",
           "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@5.2.1/lib/system/single-spa.min.js",

--- a/test/index.html
+++ b/test/index.html
@@ -11,7 +11,9 @@
         "imports": {
           "a": "./a.js",
           "react": "https://cdn.jsdelivr.net/npm/react@16.12.0/umd/react.production.min.js",
-          "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.12.0/umd/react-dom.production.min.js"
+          "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.12.0/umd/react-dom.production.min.js",
+          "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@5.2.1/lib/system/single-spa.min.js",
+          "rxjs": "https://cdn.jsdelivr.net/npm/@esm-bundle/rxjs/system/rxjs.min.js"
         }
       }
     </script>


### PR DESCRIPTION
Resolves #10. This PR does the following:

1. Add js api and ui for disabling/re-enabling modules
2. Add new apis `getDefaultMap()`, `getCurrentPageMap()`, and `getNextPageMap()`
3. Add single-spa dev lib
4. Rework the UI to be in a table and to (hopefully) look a bit better.