### PR TITLE
FIX: Incorrect variable name

### DIFF
--- a/src/api/js-api.js
+++ b/src/api/js-api.js
@@ -321,9 +321,9 @@ if (overridableImportMap) {
     });
   }
 } else {
-  if (Object.keys(overrideMap.imports).length > 0) {
+  if (Object.keys(initialOverrideMap.imports).length > 0) {
     referenceNode = insertOverrideMap(
-      overrideMap,
+      initialOverrideMap,
       `import-map-overrides`,
       referenceNode
     );

--- a/test/index.html
+++ b/test/index.html
@@ -22,5 +22,9 @@
   </head>
   <body>
     <import-map-overrides-full dev-libs></import-map-overrides-full>
+    <ul>
+      <li>With embedded map (current)</li>
+      <li><a href="no-map.html">Without embedded map</a></li>
+    </ul>
   </body>
 </html>

--- a/test/no-map.html
+++ b/test/no-map.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Import Map Overrides test</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="importmap-type" content="systemjs-importmap" />
+    <script src="/import-map-overrides.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/systemjs/dist/system.js"></script>
+  </head>
+  <body>
+    <import-map-overrides-full dev-libs></import-map-overrides-full>
+    <ul>
+      <li><a href="index.html">With embedded map</a></li>
+      <li>Without embedded map (current)</li>
+    </ul>
+  </body>
+</html>


### PR DESCRIPTION
v1.14.0 (#20) introduced a whole new behavior for externally overriding map, but it introduced an error when there's no `<script type="overridable-importmap" />` tag present:
<img width="603" alt="overrideMap-error" src="https://user-images.githubusercontent.com/679761/77426470-34d81d80-6ddd-11ea-899c-9786bad3750d.png">

This renames the variable, and adds additional test page that reproduces the problem (and shows it is fixed after the 76c90fb)