### PR TITLE
fix: toggling override status

### DIFF
--- a/src/api/js-api.js
+++ b/src/api/js-api.js
@@ -44,7 +44,7 @@ window.importMapOverrides = {
       const key = localStorage.key(i);
       if (key.indexOf(localStoragePrefix) === 0) {
         const moduleName = key.slice(localStoragePrefix.length);
-        if (includeDisabled || !disabledOverrides.indexOf(moduleName) >= 0) {
+        if (includeDisabled || !(disabledOverrides.indexOf(moduleName) >= 0)) {
           overrides.imports[moduleName] = localStorage.getItem(key);
         }
       }


### PR DESCRIPTION
Hey @joeldenning 👋 

First, thanks a lot for this package! 
It's really helping us to develop without having to spin up several MFEs. 🙇 

There's only one issue I came across when trying to `disable/apply` an override. 
Essentially, when disabling an override it is not falling back to the default value.

After debugging it, I've found that the culprit is this condition due to the order of evaluation of the last condition: `!disabledOverrides.indexOf(moduleName) >= 0` -> `!(disabledOverrides.indexOf(moduleName) >= 0)`.

Cheers,