### PR TITLE
Implementing server-side overrides.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,5 +24,22 @@
     "es5/no-shorthand-properties": "off",
     "es5/no-rest-parameters": "off",
     "es5/no-template-literals": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["src/server/**/*"],
+      "rules": {
+        "es5/no-es6-methods": "off",
+        "es5/no-es6-static-methods": "off",
+        "es5/no-binary-and-octal-literals": "off",
+        "es5/no-classes": "off",
+        "es5/no-for-of": "off",
+        "es5/no-generators": "off",
+        "es5/no-object-super": "off",
+        "es5/no-typeof-symbol": "off",
+        "es5/no-unicode-code-point-escape": "off",
+        "es5/no-unicode-regex": "off"
+      }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,15 @@ Here are some tutorial videos that explain this in more depth:
 The UI for import-map-overrides works in evergreen browsers (web components support required). The javascript API works in IE11+.
 
 - [Security](/docs/security.md)
-- [Installation](/docs/installation.md)
+
+### Browser
+
+- [Installation](/docs/installation.md#browser)
 - [Configuration](/docs/configuration.md)
 - [User Interface](/docs/ui.md)
-- [Javascript API](/docs/api.md)
+- [Javascript API](/docs/api.md#browser)
+
+### NodeJS
+
+- [Installation](/docs/installation.md#node)
+- [API](/docs/node.md#node)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,9 +1,11 @@
 # Javascript API
 
+## Browser
+
 import-map-overrides provides the following functions. Note that these functions are always put onto window.importMapOverrides, even
 if you installed it as an npm package.
 
-## getOverrideMap
+### getOverrideMap
 
 Returns the override import map as an object. The returned object represents the overrides
 **that will take effect the next time you reload the page**, including any additions or removals you've recently made after
@@ -36,7 +38,7 @@ const overrideMapWithDisabledOverrides = window.importMapOverrides.getOverrideMa
 */
 ```
 
-## addOverride
+### addOverride
 
 A function that accepts a string `moduleName` and a string `url` as arguments. This will set up an override **which takes effect
 the next time you reload the page**. Returns the new override import map.
@@ -50,7 +52,7 @@ window.importMapOverrides.addOverride("react", "https://unpkg.com/react");
 window.importMapOverrides.addOverride("module1", "8085");
 ```
 
-## removeOverride
+### removeOverride
 
 A function that accepts a string `moduleName` as an argument. This will remove an override **which takes effect the next time you
 reload the page**. Returns a boolean that indicates whether the override existed.
@@ -60,7 +62,7 @@ const wasRemoved = window.importMapOverrides.removeOverride("vue");
 console.log(wasRemoved); // Either true or false
 ```
 
-## resetOverrides
+### resetOverrides
 
 A function that removes all overrides from local storage, so that the next time the page is reloaded an override import map won't be created. Accepts
 no arguments and returns the reset override import map.
@@ -69,7 +71,7 @@ no arguments and returns the reset override import map.
 window.importMapOverrides.resetOverrides();
 ```
 
-## getUrlFromPort
+### getUrlFromPort
 
 A function used internally by import-map-overrides to create a full url when calling `addOverride()` with just a
 port number:
@@ -93,13 +95,13 @@ window.importMapOverrides.addOverride("module1", "8085");
 console.log(window.importMapOverrides.getOverrideMap().imports.module1); // "http://127.0.0.1:8085/module1.js"
 ```
 
-## enableUI
+### enableUI
 
 This will force the full import map overrides UI to be displayed (as long as the code for it is loaded on the page).
 
 It will set local storage to match the `show-when-local-storage` key and/or it will append a `<import-map-overrides-full>` element to the DOM.
 
-## mergeImportMap
+### mergeImportMap
 
 This function accepts two arguments, `firstMap` and `secondMap`, and creates a new import map that is the first map merged with the second map. Items in the second map take priority.
 
@@ -111,7 +113,7 @@ const secondMap = { imports: { foo: "./foo2.js" } };
 window.importMapOverrides.mergeImportMap(firstMap, secondMap);
 ```
 
-## getDefaultMap
+### getDefaultMap
 
 This function returns a promise that resolves the import map(s) on the page, without the presence of any import map overrides.
 
@@ -123,7 +125,7 @@ window.importMapOverrides.getDefaultMap().then((importMap) => {
 });
 ```
 
-## getCurrentPageMap
+### getCurrentPageMap
 
 This function returns a promise that resolves the final import map (including overrides) that was applied to the current page. Any overrides set after the page load will not be included.
 
@@ -136,7 +138,7 @@ window.importMapOverrides.getCurrentPageMap().then((importMap) => {
 });
 ```
 
-## getNextPageMap
+### getNextPageMap
 
 This function returns a promise that resolves with the final import map (including overrides) that will be applied the next time the page is reloaded.
 
@@ -148,7 +150,7 @@ window.importMapOverrides.getNextPageMap().then((importMap) => {
 });
 ```
 
-## disableOverride
+### disableOverride
 
 This function accepts one argument, `moduleName`, and will temporarily disable an import map override. This is similar to `removeOverride()` except that it will preserve what the override URL was so that you can toggle the override on and off.
 
@@ -159,7 +161,7 @@ Returns true if the module was already disabled, and false otherwise.
 window.importMapOverrides.disableOverride("some-module");
 ```
 
-## enableOverride
+### enableOverride
 
 This function accepts one argument, `moduleName`, and will will re-renable an import map override that was previously disabled via `disableOverride()`.
 
@@ -170,7 +172,7 @@ Returns true if the module was already disabled, and false otherwise.
 window.importMapOverrides.enableOverride("some-module");
 ```
 
-## getDisabledOverrides
+### getDisabledOverrides
 
 A function that returns an array of strings, where each string is the name of a module that is currently disabled.
 
@@ -179,7 +181,7 @@ A function that returns an array of strings, where each string is the name of a 
 window.importMapOverrides.getDisabledOverrides();
 ```
 
-## isDisabled
+### isDisabled
 
 A function that accepts one argument, `moduleName`, and returns a boolean indicated whether the string module name is a currently disabled or not.
 
@@ -188,7 +190,7 @@ A function that accepts one argument, `moduleName`, and returns a boolean indica
 window.importMapOverrides.isDisabled("module-1");
 ```
 
-## addExternalOverride
+### addExternalOverride
 
 A function that accepts one argument, `urlToImportMap`, that sets up an override to an external import map that is hosted at a different URL. The external import map has lower precendence than inline overrides created via `addOverride()` when using multiple import maps, and higher precedence when using a single import map.
 
@@ -198,7 +200,7 @@ window.importMapOverrides.addExternalOverride(
 );
 ```
 
-## removeExternalOverride
+### removeExternalOverride
 
 A function that accepts one argument, `urlToImportMap`, that removes an external import map override. Returns a boolean that indicates whether the override existed in the first place.
 
@@ -209,7 +211,7 @@ window.importMapOverrides.removeExternalOverride(
 );
 ```
 
-## getExternalOverrides
+### getExternalOverrides
 
 A function that returns an array of string URLs, where each string is the URL to an external override import map.
 
@@ -218,7 +220,7 @@ A function that returns an array of string URLs, where each string is the URL to
 window.importMapOverrides.getExternalOverrides();
 ```
 
-## getCurrentPageExternalOverrides
+### getCurrentPageExternalOverrides
 
 Similar to `getExternalOverrides()`, except it ignores any changes to the external overrides since the page was loaded.
 
@@ -227,7 +229,7 @@ Similar to `getExternalOverrides()`, except it ignores any changes to the extern
 window.importMapOverrides.getExternalOverrides();
 ```
 
-## getExternalOverrideMap
+### getExternalOverrideMap
 
 A function that returns a promise that resolves with the merged import map of all external override import maps. You can provide an array of strings `urlsToImportMap` to control which external import maps to fetch and merge.
 
@@ -245,7 +247,7 @@ window.importMapOverrides
   });
 ```
 
-## isExternalMapValid
+### isExternalMapValid
 
 Takes one argument, `urlToImport`, and returns a promise that resolves with a boolean. When `true`, the url provided is one that hosts a valid import map. When `false`, the url provided doesn't host a valid import map.
 
@@ -256,7 +258,7 @@ window.importMapOverrides.isExternalMapValid(
 );
 ```
 
-## Events
+### Events
 
 The import-map-overrides library fires an event called `import-map-overrides:change` on the window whenever the
 override import map changes. The event is a [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent)
@@ -273,4 +275,68 @@ window.removeEventListener("import-map-overrides:change", logImportMap);
 function logImportMap(evt) {
   console.log(window.importMapOverrides.getOverrideMap());
 }
+```
+
+## Node
+
+import-map-overrides exposes functions for applying overrides to import maps in NodeJS. This is commonly paired with [`@node-loader/import-maps`](https://github.com/node-loader/node-loader-import-maps), but can be used with any javascript object that is an import map.
+
+### applyOverrides
+
+A function that merges overrides into an import map.
+
+**Arguments:**
+
+- `importMap`: An object that is an import map (has an `imports` object property)
+- `overrides`: An object where the keys are import specifiers and the values are their URLs in the import map.
+
+**Return value:**
+
+A **new** import map with the overrides applied. The original map remains unmodified.
+
+```js
+import { applyOverrides } from "import-map-overrides";
+
+const importMap = {
+  imports: {
+    foo: "./foo.js",
+    bar: "./bar.js",
+  },
+};
+
+const overrides = {
+  bar: "./overridden-bar.js",
+};
+
+const overriddenMap = applyOverrides(importMap, overrides);
+/*
+{
+  imports: {
+    foo: './foo.js',
+    bar: './overridden-bar.js'
+  }
+}
+*/
+```
+
+### getOverridesFromCookies
+
+A function that accepts an [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) (commonly referred to as `req`) and returns an object of import map overrides.
+
+**Arguments:**
+
+- `req` (required): An [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage). The `req` objects from Express / Hapi servers are supported.
+- `getUrlFromPort` (optional): A function that converts a port number to a full URL. Defaults to generating a localhost URL.
+
+```js
+import { getOverridesFromCookies, applyOverrides } from "import-map-overrides";
+
+const overrides = getOverridesFromCookies(req);
+
+const mapWithOverrides = applyOverrides(originalMap, overrides);
+
+// Optionally convert port numbers to URLs
+const overrides = getOverridesFromCookies(req, (port, moduleName, req) => {
+  return `https://localhost:${port}/${moduleName}.js`;
+});
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -321,7 +321,7 @@ const overriddenMap = applyOverrides(importMap, overrides);
 
 ### getOverridesFromCookies
 
-A function that accepts an [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) (commonly referred to as `req`) and returns an object of import map overrides.
+A function that accepts an [HTTP Incoming Message](https://nodejs.org/api/http.html#http_class_http_incomingmessage) (commonly referred to as `req`) and returns an object of import map overrides. The cookies are generally set by the import-map-overrides browser library, and are of the format `import-map-override:module-name=https://localhost:8080/module-name.js`.
 
 **Arguments:**
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,7 @@
 # Installation
 
+## Browser
+
 The import-map-overrides library is used via a global variable `window.importMapOverrides`. The global variable exists because import-map-overrides needs
 to be usable regardless of build config and without dependence on ESM modules, since
 [once you use ESM modules you can no longer modify the import map](https://github.com/WICG/import-maps/blob/master/spec.md#acquiring-import-maps).
@@ -38,3 +40,29 @@ import "import-map-overrides"; // this only will work if you compile the `import
 ```
 
 Once installed, you may need to [configure import-map-overrides](/docs/configuration.md).
+
+## Node
+
+```sh
+npm install --save import-map-overrides
+
+# alternatively
+yarn add import-map-overrides
+```
+
+The import-map-overrides library is published as an ES module, not CommonJS. This means that for older versions of NodeJS, you'll need to add the `--experimental-modules` flag [Details](https://medium.com/@nodejs/announcing-a-new-experimental-modules-1be8d2d6c2ff).
+
+If your NodeJS project is CommonJS, you should load import-map-overrides via `import()`, not `require()`. [Explanation](https://nodejs.org/api/esm.html#esm_import_expressions)
+
+import-map-overrides also relies on the package.json [`type`](https://nodejs.org/api/esm.html#esm_package_json_type_field) and [`exports`](https://nodejs.org/api/esm.html#esm_package_entry_points) fields being interpreted correctly, which older versions of NodeJS do not do.
+
+```js
+// If your project is ESM
+import { applyOverrides, getOverridesFromCookies } from 'import-map-overrides';
+
+// If your project is CommonJS
+import('import-map-overrides').then(ns => {
+  ns.applyOverrides(...)
+  ns.getOverridesFromCookies(...)
+})
+```

--- a/docs/node.md
+++ b/docs/node.md
@@ -1,1 +1,0 @@
-# NodeJS Usage

--- a/docs/node.md
+++ b/docs/node.md
@@ -1,0 +1,1 @@
+# NodeJS Usage

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,8 +1,14 @@
 # Security
 
+## Browser
+
 The import-map-overrides library allows a user to modify which javascript code is executed in their browser. This is something the user can do to themself **even without import-map-overrides** by executing code in the browser console or by falling victim to a [self XSS](https://en.wikipedia.org/wiki/Self-XSS) attack. Import map overrides does not make it more possible for the user to fall victim to such an attack.
 
 However, there are things you can do to protect your users from self XSS. Consider the following security precautions:
 
 1. (**Most Important and Highly Recommended**) Configure your server to set a [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) HTTP header for your HTML file. In it, consider safelisting the domains that you trust. Doing so is important to protect your users from XSS and other attacks.
 1. Consider removing import-map-overrides from your production application's HTML file, or [configuring a domain list](/docs/configuration.md#domain-list) that disables import map overrides in production. If you properly set a Content-Security-Policy header, this provides no extra security. However, if you have not configured CSP, this will at least make it a bit harder for the user to self XSS. My recommendation is to do CSP instead of this whenever possible.
+
+## Node
+
+import-map-overrides allows a user to change which code the server executes by sending a cookie. This is helpful as a development tool, but dangerous and unsafe for deployed and production environments. As such, import-map-overrides should only be enabled on servers where you are okay with arbitrary code execution.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "import-map-overrides",
   "version": "1.17.1",
   "main": "dist/import-map-overrides.js",
+  "type": "module",
   "repository": "https://github.com/joeldenning/import-map-overrides.git",
   "author": "Joel Denning <joeldenning@gmail.com>",
   "license": "MIT",
@@ -16,14 +17,23 @@
     "lint": "eslint src",
     "prepublishOnly": "yarn build"
   },
+  "exports": {
+    "node": "./dist/import-map-overrides-server.js",
+    "default": "./dist/import-map-overrides.js"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "concurrently \"yarn lint\" \"pretty-quick --staged\""
     }
   },
-  "browserslist": [
-    "IE >= 11"
-  ],
+  "browserslist": {
+    "production": [
+      "IE >= 11"
+    ],
+    "server": [
+      "Node 10"
+    ]
+  },
   "files": [
     "dist"
   ],
@@ -51,5 +61,7 @@
     "rollup-plugin-terser": "^6.1.0",
     "serve": "^11.3.2"
   },
-  "dependencies": {}
+  "dependencies": {
+    "cookie": "^0.4.1"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -57,6 +57,38 @@ export default [
         }),
     ],
   },
+  // Server ESM
+  {
+    input: "src/import-map-overrides-server.js",
+    output: {
+      banner: `/* import-map-overrides@${packageJson} (server) */`,
+      file: "dist/import-map-overrides-server.js",
+      format: "es",
+      sourcemap: true,
+    },
+    plugins: [
+      babel({
+        exclude: "node_modules/**",
+        presets: [
+          [
+            "@babel/preset-env",
+            {
+              browserslistEnv: "server",
+            },
+          ],
+        ],
+      }),
+      isProduction &&
+        terser({
+          compress: {
+            passes: 2,
+          },
+          output: {
+            comments: terserComments,
+          },
+        }),
+    ],
+  },
 ];
 
 function terserComments(node, comment) {

--- a/src/import-map-overrides-server.js
+++ b/src/import-map-overrides-server.js
@@ -1,0 +1,1 @@
+export * from "./server/server-api";

--- a/src/server/server-api.js
+++ b/src/server/server-api.js
@@ -1,0 +1,67 @@
+import cookie from "cookie";
+
+const cookiePrefix = "import-map-override:";
+const portRegex = /^\d+$/g;
+
+/**
+ * @typedef {
+ *   imports: object,
+ *   scopes?: object
+ * } ImportMap
+ *
+ * @param {ImportMap} importMap
+ * @param {overrides} object
+ * @returns {ImportMap}
+ */
+export function applyOverrides(importMap, overrides) {
+  const newMap = {
+    imports: { ...importMap.imports },
+    scopes: { ...(importMap.scopes || {}) },
+  };
+  for (let key in overrides) {
+    newMap.imports[key] = overrides[key];
+  }
+
+  return newMap;
+}
+
+/**
+ *
+ * @param {import('http').IncomingMessage} req
+ * @returns {ImportMap}
+ */
+export function getOverridesFromCookies(
+  req,
+  getUrlFromPort = defaultGetUrlFromPort
+) {
+  const parsedCookies = cookie.parse(req.headers["cookie"] || "");
+
+  const overrides = {};
+
+  for (let cookieName in parsedCookies) {
+    if (cookieName.startsWith(cookiePrefix)) {
+      const moduleName = cookieName.slice(cookiePrefix.length);
+
+      // skip empty string
+      if (moduleName) {
+        let url = parsedCookies[cookieName];
+        if (portRegex.test(url)) {
+          url = (getUrlFromPort || defaultGetUrlFromPort)(url, moduleName, req);
+        }
+
+        if (url.startsWith("//")) {
+          url = `${req.protocol}:${url}`;
+        }
+
+        overrides[moduleName] = url;
+      }
+    }
+  }
+
+  return overrides;
+}
+
+function defaultGetUrlFromPort(port, moduleName, req) {
+  const fileName = moduleName.replace(/@/g, "").replace(/\//g, "-");
+  return `${req.protocol}://localhost:${port}/${fileName}`;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,6 +1516,11 @@ convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 copyfiles@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.3.0.tgz#1c26ebbe3d46bba2d309a3fd8e3aaccf53af8c76"


### PR DESCRIPTION
This allows import map overrides set up in the browser to apply when server rendering. This will be a breaking change since it changes the package.json type and exports.