### PR TITLE
Update link to node api

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ The UI for import-map-overrides works in evergreen browsers (web components supp
 ### NodeJS
 
 - [Installation](/docs/installation.md#node)
-- [API](/docs/node.md#node)
+- [API](/docs/api.md#node)
+


### PR DESCRIPTION
Hello, the current link for the node api documentation seems to be broken.