### PR TITLE
Fix port regex statefulness error. Resolves #27.

### DIFF
--- a/src/api/js-api.js
+++ b/src/api/js-api.js
@@ -11,8 +11,6 @@ const allowListPrefix = "allowlist:";
 const denyListPrefix = "denylist:";
 export const queryParamOverridesName = "imo";
 
-const portRegex = /^\d+$/g;
-
 const importMapMetaElement = document.querySelector(
   'meta[name="importmap-type"]'
 );
@@ -77,6 +75,7 @@ function init() {
 
   window.importMapOverrides = {
     addOverride(moduleName, url) {
+      const portRegex = /^\d+$/g;
       if (portRegex.test(url)) {
         url = imo.getUrlFromPort(moduleName, url);
       }


### PR DESCRIPTION
See #27. Javascript regexes are stateful, and the code reused the same regex over and over again. So the result of `portRegex.test()` would be true/false depending on that statefulness.

To fix, I switched to recreating the regex every time rather than reusing.