### PR TITLE
Cross domain window parent fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "watch": "cross-env NODE_ENV=development rollup -c --watch",
     "copy-test-files": "copyfiles test/**/* dist -f",
     "test-serve": "serve .",
-    "test": "concurrently pnpm:watch pnpm:copy-test-files pnpm:test-serve",
+    "test-embed-serve": "serve . -l 3333",
+    "test": "concurrently pnpm:watch pnpm:copy-test-files pnpm:test-serve pnpm:test-embed-serve",
     "lint": "eslint src",
     "prepublishOnly": "pnpm run build",
     "prepare": "husky install"

--- a/src/api/js-api.js
+++ b/src/api/js-api.js
@@ -111,7 +111,9 @@ function init() {
       // get from url if query param exist
       const queryParam = getParameterByName(
         queryParamOverridesName,
-        window.parent ? window.parent.location.href : window.location.href
+        window.location != window.parent.location
+          ? document.referrer
+          : window.location.href
       );
 
       if (queryParam) {

--- a/test/index.html
+++ b/test/index.html
@@ -65,5 +65,9 @@
       </ul>
     </div>
     <iframe id="testFrame" src="./embedded-map.html"></iframe>
+    <iframe
+      id="testFrame_cross_domain"
+      src="http://localhost:3333/embedded-map.html"
+    ></iframe>
   </body>
 </html>


### PR DESCRIPTION
Hi @joeldenning I hope I'm doing right by you 🙏 

Closes issue #61 

**Problem:**
- Currently, import-map-overrides attempts to access `window.parent.location.href` regardless of parent origin
- As a result, when one site (say microsoft.com) renders an iframe containing an SPA that uses import-map-overrides (let's say, app.thriveglobal.com), import-map-overrides attempts to read `window.parent.location.href` as a `window.parent` is present
- This has a resulting effect of disrupting the user experience for the SPA

**Proposed Solution:**
- Check if the locations of `window` and `window.parent` are the same before attempting to inspect the parent for query params.
- Use `document.referer` if window.parent is present & doesn't match window.location
- Otherwise use `window.location.href` normally

Reproduction locally:
![Screen Shot 2022-01-12 at 4 21 50 PM](https://user-images.githubusercontent.com/8388/149224394-9fd890ef-c62e-4144-b502-0c4f00d2c3a4.png)

Resolution after my proposed solution:
![Screen Shot 2022-01-12 at 4 23 10 PM](https://user-images.githubusercontent.com/8388/149224395-130ba2f2-9dcd-4158-9f87-49fa9ca2ae9b.png)