### PR TITLE
Prevent CSS conflicts breaking UI

### DIFF
--- a/src/ui/custom-elements.js
+++ b/src/ui/custom-elements.js
@@ -1,4 +1,4 @@
-import "./import-map-overrides.css";
+import styles from "./import-map-overrides.css";
 import { render, h } from "preact";
 import FullUI from "./full-ui.component";
 import Popup from "./popup.component";
@@ -36,11 +36,15 @@ function preactCustomElement(Comp, observedAttributes = []) {
       this.renderWithPreact();
     }
     renderWithPreact() {
+      this.shadow = this.attachShadow({ mode: "open" });
       this.renderedEl = render(
         h(Comp, { customElement: this }),
-        this,
+        this.shadow,
         this.renderedEl
       );
+      const style = document.createElement("style");
+      style.textContent = styles.toString();
+      this.shadow.appendChild(style);
     }
   };
 }


### PR DESCRIPTION
Renders UI to ShadowDOM elements, preventing external CSS rules interfering with desired import-map UI.

Resolves #63 but also prevents future issues unlike the solution in #64.